### PR TITLE
Fix admin page prerender settings to avoid Vercel build error

### DIFF
--- a/app/admin/AdminClient.tsx
+++ b/app/admin/AdminClient.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import NextDynamic from "next/dynamic";
+
+// Si tu panel está en otra ruta, ajusta el import.
+// En tu repo suele ser "@/components/admin"
+const Admin = NextDynamic(() => import("@/components/admin"), {
+  ssr: false,
+  loading: () => null,
+});
+
+export default function AdminClient() {
+  return <Admin />;
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,20 +1,11 @@
 // app/admin/page.tsx
-"use client";
+import AdminClient from "./AdminClient";
 
 // ✅ Fuerza render 100% cliente (sin SSG/ISR)
 export const dynamic = "force-dynamic";
-export const revalidate = 0;            // número >= 0 (0 = no cache)
+export const revalidate = 0; // número >= 0 (0 = no cache)
 export const fetchCache = "force-no-store";
 
-import dynamic from "next/dynamic";
-
-// Si tu panel está en otra ruta, ajusta el import.
-// En tu repo suele ser "@/components/admin"
-const Admin = dynamic(() => import("@/components/admin"), {
-  ssr: false,
-  loading: () => null,
-});
-
 export default function AdminPage() {
-  return <Admin />;
+  return <AdminClient />;
 }


### PR DESCRIPTION
## Summary
- fix admin page to export server-side rendering directives
- add client wrapper to load admin panel without SSR

## Testing
- `pnpm lint` *(fails: prompts for ESLint configuration)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68c5c271a4f4832888355c1536bd4eab