### PR TITLE
Move rainbowkit styles to layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from "next";
 import Providers from "./providers";
 import { Toaster } from "sonner";
 import "./globals.css";
+import "@rainbow-me/rainbowkit/styles.css";
 
 export const metadata: Metadata = {
   title: "Carbono & Experiencia - Web3 DApp",

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,7 +1,5 @@
 // app/providers.tsx
 "use client";
-
-import "@rainbow-me/rainbowkit/styles.css";
 import type { ReactNode } from "react";
 import { WagmiProvider } from "wagmi";
 import { RainbowKitProvider } from "@rainbow-me/rainbowkit";


### PR DESCRIPTION
## Summary
- move rainbowkit styles import to app layout so styles load before rendering
- remove duplicated style import from providers

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68c5fed8c558832891367dbd56581bdd